### PR TITLE
Name resolution

### DIFF
--- a/internal/catalog/functions/defaults.go
+++ b/internal/catalog/functions/defaults.go
@@ -12,6 +12,7 @@ func DefaultFunctions() map[string]impls.Function {
 	m := map[string]impls.Function{}
 	for _, f := range []impls.Function{
 		now,
+		length,
 		currval,
 		nextval,
 		setval,
@@ -28,6 +29,16 @@ var now = newFunctionImpl(
 	types.TypeTimestampTz,
 	func(ctx impls.ExecutionContext, args []any) (any, error) {
 		return time.Now(), nil
+	},
+)
+
+var length = newFunctionImpl(
+	"length",
+	[]types.Type{types.TypeText},
+	types.TypeBigInteger,
+	func(ctx impls.ExecutionContext, args []any) (any, error) {
+		value := args[0].(string)
+		return int64(len(value)), nil
 	},
 )
 

--- a/internal/shared/impls/context.go
+++ b/internal/shared/impls/context.go
@@ -25,10 +25,14 @@ type NodeResolutionContext struct {
 	Catalog CatalogSet
 }
 
-func NewNodeResolutionContext(catalog CatalogSet) NodeResolutionContext {
-	return NodeResolutionContext{
+func NewNodeResolutionContext(catalog CatalogSet) *NodeResolutionContext {
+	return &NodeResolutionContext{
 		Catalog: catalog,
 	}
+}
+
+func (ctx *NodeResolutionContext) ExpressionResolutionContext() ExpressionResolutionContext {
+	return NewExpressionResolutionContext(ctx.Catalog)
 }
 
 //

--- a/internal/syntax/ast/builder.go
+++ b/internal/syntax/ast/builder.go
@@ -6,7 +6,7 @@ import (
 )
 
 type Resolver interface {
-	Resolve(ctx impls.NodeResolutionContext) error
+	Resolve(ctx *impls.NodeResolutionContext) error
 }
 
 type Builder interface {

--- a/internal/syntax/ast/delete.go
+++ b/internal/syntax/ast/delete.go
@@ -21,7 +21,7 @@ type DeleteBuilder struct {
 	table impls.Table
 }
 
-func (b *DeleteBuilder) Resolve(ctx impls.NodeResolutionContext) error {
+func (b *DeleteBuilder) Resolve(ctx *impls.NodeResolutionContext) error {
 	table, ok := ctx.Catalog.Tables.Get(b.Target.Name)
 	if !ok {
 		return fmt.Errorf("unknown table %q", b.Target.Name)

--- a/internal/syntax/ast/expressions.go
+++ b/internal/syntax/ast/expressions.go
@@ -1,0 +1,30 @@
+package ast
+
+import (
+	"github.com/efritz/gostgres/internal/execution/expressions"
+	"github.com/efritz/gostgres/internal/shared/impls"
+)
+
+func ResolveExpression(ctx *impls.NodeResolutionContext, expr impls.Expression) (impls.Expression, error) {
+	mappedExpr, err := expr.Map(func(expr impls.Expression) (impls.Expression, error) {
+		if named, ok := expr.(expressions.NamedExpression); ok {
+			field, err := ctx.Lookup(named.Field().RelationName(), named.Field().Name())
+			if err != nil {
+				return nil, err
+			}
+
+			return expressions.NewNamed(field), nil
+		}
+
+		return expr, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if err := expr.Resolve(ctx.ExpressionResolutionContext()); err != nil {
+		return nil, err
+	}
+
+	return mappedExpr, nil
+}

--- a/internal/syntax/ast/expressions.go
+++ b/internal/syntax/ast/expressions.go
@@ -6,6 +6,10 @@ import (
 )
 
 func ResolveExpression(ctx *impls.NodeResolutionContext, expr impls.Expression) (impls.Expression, error) {
+	if expr == nil {
+		return nil, nil
+	}
+
 	mappedExpr, err := expr.Map(func(expr impls.Expression) (impls.Expression, error) {
 		if named, ok := expr.(expressions.NamedExpression); ok {
 			field, err := ctx.Lookup(named.Field().RelationName(), named.Field().Name())

--- a/internal/syntax/ast/expressions.go
+++ b/internal/syntax/ast/expressions.go
@@ -5,7 +5,7 @@ import (
 	"github.com/efritz/gostgres/internal/shared/impls"
 )
 
-func ResolveExpression(ctx *impls.NodeResolutionContext, expr impls.Expression) (impls.Expression, error) {
+func resolveExpression(ctx *impls.NodeResolutionContext, expr impls.Expression) (impls.Expression, error) {
 	if expr == nil {
 		return nil, nil
 	}

--- a/internal/syntax/ast/insert.go
+++ b/internal/syntax/ast/insert.go
@@ -18,7 +18,7 @@ type InsertBuilder struct {
 	table impls.Table
 }
 
-func (b *InsertBuilder) Resolve(ctx impls.NodeResolutionContext) error {
+func (b *InsertBuilder) Resolve(ctx *impls.NodeResolutionContext) error {
 	table, ok := ctx.Catalog.Tables.Get(b.Target.Name)
 	if !ok {
 		return fmt.Errorf("unknown table %q", b.Target.Name)

--- a/internal/syntax/ast/select.go
+++ b/internal/syntax/ast/select.go
@@ -41,7 +41,7 @@ type CombinationDescription struct {
 	Select   TableReferenceOrExpression
 }
 
-func (b *SelectBuilder) Resolve(ctx impls.NodeResolutionContext) error {
+func (b *SelectBuilder) Resolve(ctx *impls.NodeResolutionContext) error {
 	if err := b.Select.From.Resolve(ctx); err != nil {
 		return err
 	}

--- a/internal/syntax/ast/select.go
+++ b/internal/syntax/ast/select.go
@@ -109,8 +109,7 @@ func (b *SelectBuilder) resolvePrimarySelect(ctx *impls.NodeResolutionContext) e
 			return err
 		}
 
-		// TODO - vet
-		resolved2, err := resolved.Map(func(expr impls.Expression) (impls.Expression, error) {
+		resolved, err = resolved.Map(func(expr impls.Expression) (impls.Expression, error) {
 			if named, ok := expr.(expressions.NamedExpression); ok {
 				for _, pair := range projection.Aliases() {
 					if pair.Alias == named.Field().Name() {
@@ -125,8 +124,7 @@ func (b *SelectBuilder) resolvePrimarySelect(ctx *impls.NodeResolutionContext) e
 			return err
 		}
 
-		fmt.Printf("> %s vs %s vs %s\n", expr, resolved, resolved2) // DEBUG
-		b.Select.Groupings[i] = resolved2
+		b.Select.Groupings[i] = resolved
 	}
 
 	if b.Order != nil {

--- a/internal/syntax/ast/tables.go
+++ b/internal/syntax/ast/tables.go
@@ -26,7 +26,7 @@ type TableReference struct {
 	table impls.Table
 }
 
-func (r *TableReference) Resolve(ctx impls.NodeResolutionContext) error {
+func (r *TableReference) Resolve(ctx *impls.NodeResolutionContext) error {
 	table, ok := ctx.Catalog.Tables.Get(r.Name)
 	if !ok {
 		return fmt.Errorf("unknown table %q", r.Name)
@@ -76,7 +76,7 @@ type Join struct {
 	Condition impls.Expression
 }
 
-func (r *TableExpression) Resolve(ctx impls.NodeResolutionContext) error {
+func (r *TableExpression) Resolve(ctx *impls.NodeResolutionContext) error {
 	if err := r.Base.BaseTableExpression.Resolve(ctx); err != nil {
 		return err
 	}

--- a/internal/syntax/ast/tables.go
+++ b/internal/syntax/ast/tables.go
@@ -104,8 +104,9 @@ func (e *TableExpression) Resolve(ctx *impls.NodeResolutionContext) error {
 			}
 
 			for i, field := range rawFields {
-				baseFields[i] = field.WithName(columnAliases[i])
-				e.projectionExpressions = append(e.projectionExpressions, projectionHelpers.NewAliasedExpression(expressions.NewNamed(field), columnAliases[i]))
+				alias := columnAliases[i]
+				baseFields[i] = field.WithName(alias)
+				e.projectionExpressions = append(e.projectionExpressions, projectionHelpers.NewAliasedExpression(expressions.NewNamed(field), alias))
 			}
 		} else {
 			baseFields = rawFields

--- a/internal/syntax/ast/tables.go
+++ b/internal/syntax/ast/tables.go
@@ -124,7 +124,11 @@ func (e *TableExpression) Resolve(ctx *impls.NodeResolutionContext) error {
 		ctx.Bind(joinFields...)
 		baseFields = append(baseFields, joinFields...)
 
-		_ = j.Condition // TODO
+		resolved, err := resolveExpression(ctx, j.Condition)
+		if err != nil {
+			return err
+		}
+		j.Condition = resolved
 	}
 
 	e.fields = baseFields

--- a/internal/syntax/ast/update.go
+++ b/internal/syntax/ast/update.go
@@ -27,7 +27,7 @@ type SetExpression struct {
 	Expression impls.Expression
 }
 
-func (b *UpdateBuilder) Resolve(ctx impls.NodeResolutionContext) error {
+func (b *UpdateBuilder) Resolve(ctx *impls.NodeResolutionContext) error {
 	table, ok := ctx.Catalog.Tables.Get(b.Target.Name)
 	if !ok {
 		return fmt.Errorf("unknown table %q", b.Target.Name)

--- a/internal/syntax/ast/values.go
+++ b/internal/syntax/ast/values.go
@@ -14,7 +14,7 @@ type ValuesBuilder struct {
 	Expressions [][]impls.Expression
 }
 
-func (b *ValuesBuilder) Resolve(ctx impls.NodeResolutionContext) error {
+func (b *ValuesBuilder) Resolve(ctx *impls.NodeResolutionContext) error {
 	return nil
 }
 

--- a/tests/golden/TestIntegration/active-customer-emails-with-except.sql.golden
+++ b/tests/golden/TestIntegration/active-customer-emails-with-except.sql.golden
@@ -10,8 +10,8 @@ ORDER BY s.email;
 
 Plan:
 
-                 query plan
---------------------------------------------
+                     query plan
+-----------------------------------------------------
  select (email)
     order by s.email
         alias as s
@@ -21,7 +21,7 @@ Plan:
             with
                 select (email)
                     table scan of customer
-                        filter: active = 0
+                        filter: customer.active = 0
 (1 rows)
 
 Results:

--- a/tests/golden/TestIntegration/districts-ordered-by-count.sql.golden
+++ b/tests/golden/TestIntegration/districts-ordered-by-count.sql.golden
@@ -4,7 +4,7 @@ Query:
 SELECT a.district, count(1)
 FROM address a
 GROUP BY a.district
-ORDER BY a.count DESC, a.district
+ORDER BY count DESC, a.district
 LIMIT 10;
 
 Plan:
@@ -12,7 +12,7 @@ Plan:
                       query plan
 ------------------------------------------------------
  limit 10
-    order by a.count desc, a.district
+    order by count desc, a.district
         group by a.district, select(district, count)
             alias as a
                 table scan of address

--- a/tests/golden/TestIntegration/districts-ordered-by-count.sql.golden
+++ b/tests/golden/TestIntegration/districts-ordered-by-count.sql.golden
@@ -7,6 +7,8 @@ GROUP BY a.district
 ORDER BY count DESC, a.district
 LIMIT 10;
 
+-- NOTE: a.count should actually work too for some reason...?
+
 Plan:
 
                       query plan

--- a/tests/golden/TestIntegration/group-by-select-expression.sql.golden
+++ b/tests/golden/TestIntegration/group-by-select-expression.sql.golden
@@ -1,0 +1,42 @@
+`
+Query:
+
+SELECT length(f.title) AS len, count(1)
+FROM film f
+GROUP BY len
+ORDER BY len;
+
+Plan:
+
+                             query plan
+---------------------------------------------------------------------
+ order by len
+    group by length(f.title), select(length(f.title) as len, count)
+        alias as f
+            table scan of film
+(1 rows)
+
+Results:
+
+ len | count
+-----+-------
+ 8   | 6
+ 9   | 32
+ 10  | 66
+ 11  | 89
+ 12  | 116
+ 13  | 129
+ 14  | 122
+ 15  | 122
+ 16  | 104
+ 17  | 70
+ 18  | 47
+ 19  | 44
+ 20  | 23
+ 21  | 15
+ 22  | 9
+ 23  | 4
+ 25  | 1
+ 27  | 1
+(18 rows)
+`

--- a/tests/golden/TestIntegration/r-rated-films-ordered-by-title.sql.golden
+++ b/tests/golden/TestIntegration/r-rated-films-ordered-by-title.sql.golden
@@ -19,7 +19,7 @@ Plan:
             join using nested loop
                 alias as f
                     btree index scan of film via idx_title
-                        filter: rating = R
+                        filter: film.rating = R
             with
                 alias as fc
                     btree index scan of film_category via film_category_pkey

--- a/tests/queries/districts-ordered-by-count.sql
+++ b/tests/queries/districts-ordered-by-count.sql
@@ -3,3 +3,5 @@ FROM address a
 GROUP BY a.district
 ORDER BY count DESC, a.district
 LIMIT 10;
+
+-- NOTE: a.count should actually work too for some reason...?

--- a/tests/queries/districts-ordered-by-count.sql
+++ b/tests/queries/districts-ordered-by-count.sql
@@ -1,5 +1,5 @@
 SELECT a.district, count(1)
 FROM address a
 GROUP BY a.district
-ORDER BY a.count DESC, a.district
+ORDER BY count DESC, a.district
 LIMIT 10;

--- a/tests/queries/group-by-select-expression.sql
+++ b/tests/queries/group-by-select-expression.sql
@@ -1,0 +1,4 @@
+SELECT length(f.title) AS len, count(1)
+FROM film f
+GROUP BY len
+ORDER BY len;


### PR DESCRIPTION
Resolve references to fields at resolution rather than execution. The same name-lookup technique is used at execution, but should be replaced in a subsequent effort by a direct lookup of a field by a unique identifier decided at resolution time.